### PR TITLE
Bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: [20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
GitHub Actions runners switch their default Node runtime from Node 20 to
**Node 24 on June 16, 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
This bumps the actions that were pinned to Node 20–era versions so CI keeps
working after the switch.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v3` | `v6` |
| `actions/setup-node` | `v3` | `v6` |

CI maintenance only — no application or runtime code changes.

Closes #31
